### PR TITLE
Replaced isinf by std::isinf in NeatContainer to compile on Ubuntu16

### DIFF
--- a/src/evolution/engine/neat/NeatContainer.cpp
+++ b/src/evolution/engine/neat/NeatContainer.cpp
@@ -114,7 +114,7 @@ bool NeatContainer::produceNextGeneration(boost::shared_ptr<Population>
 		}
 		// use e^f so fitness is always positive
 		genome->SetFitness(exp(robot->getFitness()));
-		if (isinf(genome->GetFitness())) {
+		if (std::isinf(genome->GetFitness())) {
 			std::cerr << std::endl << "ERROR in NeatContainer!!" << std::endl
 					<< "Overflow when setting fitness for NEAT, please scale"
 					<< " down your fitness values." << std::endl << std::endl;


### PR DESCRIPTION
This fixes #58

Tested on Ubuntu16 (gcc version 5.4.0) and Ubuntu14 (gcc version 4.8.4)
