### PR TITLE
Robot starting position: fixed bug that moved robot twice by starting pos

### DIFF
--- a/src/scenario/Scenario.cpp
+++ b/src/scenario/Scenario.cpp
@@ -224,7 +224,7 @@ bool Scenario::init(dWorldID odeWorld, dSpaceID odeSpace,
 			RobogenConfig::ELEVATE_ROBOT) {
 
 		robot->translateRobot(
-				osg::Vec3(startingPosition.x(), startingPosition.y(),
+				osg::Vec3(0, 0,
 						overlapMaxZ + inMm(2) - minZ));
 	}
 


### PR DESCRIPTION
Omitted to move the robot twice by starting position.
This fixes #63 